### PR TITLE
Provide ld with path to transitive shared object dependencies 

### DIFF
--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-direct/pom.xml
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-direct/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0033-directDepsOnly-link-transitive-deps</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0033-directDepsOnly-link-transitive-deps-direct</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Shared Library Direct</name>
+  <version>1.0-SNAPSHOT</version>  
+  <description>
+    Simple shared library that depends on a shared library
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>shared</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0033-directDepsOnly-link-transitive-deps-trans</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-direct/src/main/c++/directDep.cpp
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-direct/src/main/c++/directDep.cpp
@@ -1,0 +1,7 @@
+#include "directDep.h"
+#include "transitiveDep.h"
+
+void directFunction ()
+{
+   transitiveFunction();
+}

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-direct/src/main/include/directDep.h
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-direct/src/main/include/directDep.h
@@ -1,0 +1,1 @@
+extern void directFunction();

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-exe/pom.xml
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-exe/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0033-directDepsOnly-link-transitive-deps</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0033-directDepsOnly-link-transitive-deps-exe</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Transitive Deps Executable</name>
+  <version>1.0-SNAPSHOT</version>  
+  <description>
+    An executable program that consumes a transitive dependency which is a shared object
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+
+  <build>
+    <defaultGoal>integration-test</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <directDepsOnly>true</directDepsOnly>
+          <linker>
+            <narDefaultDependencyLibOrder>true</narDefaultDependencyLibOrder>
+          </linker>
+          <libraries>
+            <library>
+              <type>executable</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0033-directDepsOnly-link-transitive-deps-direct</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-exe/src/main/c++/main.cpp
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-exe/src/main/c++/main.cpp
@@ -1,0 +1,6 @@
+#include "directDep.h"
+
+int main ()
+{
+   directFunction();
+}

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-trans/pom.xml
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-trans/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0033-directDepsOnly-link-transitive-deps</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0033-directDepsOnly-link-transitive-deps-trans</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Shared Library Trans</name>
+  <version>1.0-SNAPSHOT</version>  
+  <description>
+    Simple Shared Library
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+    
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>shared</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-trans/src/main/c++/transitiveDep.cpp
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-trans/src/main/c++/transitiveDep.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+#include "transitiveDep.h"
+
+void transitiveFunction()
+{
+   std::cout << "This output is coming from the shared object transitive dependency" << std::endl;
+}

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-trans/src/main/include/transitiveDep.h
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-trans/src/main/include/transitiveDep.h
@@ -1,0 +1,1 @@
+extern void transitiveFunction();

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/pom.xml
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0033-directDepsOnly-link-transitive-deps</artifactId>
+  <packaging>pom</packaging>
+  <name>Aggregate Direct and Transitive shared objects pom</name>
+  <version>1.0-SNAPSHOT</version>  
+  <description>
+    Aggregate for controlling dependency building order
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+  <modules>
+    <module>it0033-directDepsOnly-link-transitive-deps-trans</module>
+    <module>it0033-directDepsOnly-link-transitive-deps-direct</module>
+    <module>it0033-directDepsOnly-link-transitive-deps-exe</module>
+  </modules>
+  
+</project>

--- a/src/main/java/com/github/maven_nar/NarInfo.java
+++ b/src/main/java/com/github/maven_nar/NarInfo.java
@@ -180,6 +180,15 @@ public class NarInfo {
       return this.artifactId;
   }
 
+  /**
+   * Get the version of the NarInfo instance
+   * @return {@link String} representing a NarInfo object's version.
+   * @since 3.5.3
+   */
+  public String getVersion() {
+    return this.version;
+  }
+
   public final void read(final JarFile jar) throws IOException {
     this.info.load(jar.getInputStream(getNarPropertiesEntry(jar)));
   }

--- a/src/main/java/com/github/maven_nar/NarVcprojMojo.java
+++ b/src/main/java/com/github/maven_nar/NarVcprojMojo.java
@@ -160,7 +160,7 @@ public class NarVcprojMojo extends AbstractCompileMojo {
 
     // add linker
     final LinkerDef linkerDefinition = getLinker().getLinker(this, task, getOS(), getAOL().getKey() + ".linker.",
-        type);
+        type, null);
     task.addConfiguredLinker(linkerDefinition);
 
     // add dependency libraries


### PR DESCRIPTION
Same changes that were already reviewed here: http://crucible02.cerner.com/viewer/cru/FOUNDATIONS-4345