### PR TITLE
fix static library builds

### DIFF
--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-static-lib/pom.xml
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-static-lib/pom.xml
@@ -24,28 +24,53 @@
 
   <parent>
     <groupId>com.github.maven-nar.its.nar</groupId>
-    <artifactId>it-parent</artifactId>
+    <artifactId>it0033-directDepsOnly-link-transitive-deps</artifactId>
     <version>1.0-SNAPSHOT</version>
-    <relativePath>../it-parent/pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>it0033-directDepsOnly-link-transitive-deps</artifactId>
-  <packaging>pom</packaging>
-  <name>Aggregate Direct and Transitive shared objects pom</name>
+  <artifactId>it0033-directDepsOnly-link-transitive-deps-static-lib</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Transitive Deps Static Library</name>
   <version>1.0-SNAPSHOT</version>  
   <description>
-    Aggregate for controlling dependency building order
+    A static library that consumes a transitive dependency which is a shared object
   </description>
   <url>http://maven.apache.org/</url>
 
   <properties>
     <skipTests>true</skipTests>
   </properties>
-  <modules>
-    <module>it0033-directDepsOnly-link-transitive-deps-trans</module>
-    <module>it0033-directDepsOnly-link-transitive-deps-direct</module>
-    <module>it0033-directDepsOnly-link-transitive-deps-exe</module>
-    <module>it0033-directDepsOnly-link-transitive-deps-static-lib</module>
-  </modules>
+
+  <build>
+    <defaultGoal>integration-test</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <directDepsOnly>true</directDepsOnly>
+          <linker>
+            <narDefaultDependencyLibOrder>true</narDefaultDependencyLibOrder>
+          </linker>
+          <libraries>
+            <library>
+              <type>static</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0033-directDepsOnly-link-transitive-deps-direct</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
 </project>

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-static-lib/src/main/c++/static.cpp
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-static-lib/src/main/c++/static.cpp
@@ -1,0 +1,6 @@
+#include "directDep.h"
+
+void staticFunction()
+{
+  directFunction();
+}

--- a/src/main/java/com/github/maven_nar/Linker.java
+++ b/src/main/java/com/github/maven_nar/Linker.java
@@ -394,8 +394,8 @@ public class Linker {
         mojo.getLog().warn("directDepsOnly will have no effect since narDefaultDependencyLibOrder is disabled");
     }
 
-    // Add transitive dependencies to the shared library search path if we are on linux and directDepsOnly is enabled.
-    if (linkPaths != null && linkPaths.size() > 0 && mojo.getDirectDepsOnly() && os.equals(OS.LINUX)){
+    // Add transitive dependencies to the shared library search path if we are on linux, directDepsOnly is enabled, and this is not a static library.
+    if (linkPaths != null && linkPaths.size() > 0 && mojo.getDirectDepsOnly() && os.equals(OS.LINUX) && !type.equals("static")){
         StringBuilder argStrBuilder = new StringBuilder();
         argStrBuilder.append("-Wl,-rpath-link,");
         for (String path : linkPaths){

--- a/src/main/java/com/github/maven_nar/Linker.java
+++ b/src/main/java/com/github/maven_nar/Linker.java
@@ -395,7 +395,7 @@ public class Linker {
     }
 
     // Add transitive dependencies to the shared library search path if we are on linux, directDepsOnly is enabled, and this is not a static library.
-    if (linkPaths != null && linkPaths.size() > 0 && mojo.getDirectDepsOnly() && os.equals(OS.LINUX) && !type.equals("static")){
+    if (linkPaths != null && linkPaths.size() > 0 && mojo.getDirectDepsOnly() && os.equals(OS.LINUX) && !type.equals(Library.STATIC)){
         StringBuilder argStrBuilder = new StringBuilder();
         argStrBuilder.append("-Wl,-rpath-link,");
         for (String path : linkPaths){


### PR DESCRIPTION
Added a check to not add the -Wl,-rpath-link parameter to the linker args if we are building a static library, and added an integration test to make sure we can build static libraries with shared library transitive dependencies.